### PR TITLE
Rationale

### DIFF
--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -33,6 +33,7 @@ The Bill of Rights shall constitute the integral part of the Constitution and sh
 * **§II.15.** No law shall establish and/or regulate the institution of marriage between the adults.
 * **§II.16.** No law shall oblige any person to acquire any form of insurance and/or pension scheme, nor shall it provide any incentive in that respect.
 * **§II.17.** No law shall prohibit video and/or audio recording of any employee of the Public Administration in public space and whilst on duty.
+* **§II.18.** No law shall be written without a Rationale explaining why the law is voted and how the goal is being achieved by the law, and a Budget explaining how the law will be funded. Any judge and any jury in any lawful court seized by any citizen may nullify a law if its Rationale is found to be unconstitutional, obsolete or otherwise invalid, if the stated benefits are found not to have been achieved, or if the costs including unintended consequences are found to be greater than the stated benefits, or if its budget is being exceeded.
 
 ### Article III: Individual Rights
 

--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -33,7 +33,8 @@ The Bill of Rights shall constitute the integral part of the Constitution and sh
 * **§II.15.** No law shall establish and/or regulate the institution of marriage between the adults.
 * **§II.16.** No law shall oblige any person to acquire any form of insurance and/or pension scheme, nor shall it provide any incentive in that respect.
 * **§II.17.** No law shall prohibit video and/or audio recording of any employee of the Public Administration in public space and whilst on duty.
-* **§II.18.** No law shall be written without a Rationale explaining why the law is voted and how the goal is being achieved by the law, and a Budget explaining how the law will be funded. Any judge and any jury in any lawful court seized by any citizen may nullify a law if its Rationale is found to be unconstitutional, obsolete or otherwise invalid, if the stated benefits are found not to have been achieved, or if the costs including unintended consequences are found to be greater than the stated benefits, or if its budget is being exceeded.
+* **§II.18.** No Bill proposed to the Assembly shall be passed unless it has been read aloud in entirety by the Assembly Speaker and includes precise calculation as to its potential impact on the budget as well as rationale behind it and means of achieving thereof, which does not conflict with the Constitution.
+
 
 ### Article III: Individual Rights
 


### PR DESCRIPTION
Here's a pull request with your wording from #30.

I believe the current wording isn't enough, because it doesn't make the rationale and budget binding; these two items are toothless without an explicit mention of nullification when they are lies.
