### PR TITLE
right to bear arms

### DIFF
--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -59,7 +59,7 @@ The Bill of Rights shall constitute the integral part of the Constitution and sh
 * **§III.11.** No person shall either before or after trial be held incommunicado.
 * **§III.12.** An accused who does not speak the language in which the criminal proceedings are conducted shall be provided without expense with the services of an interpreter.
 * **§III.13.** No person shall be subject for the same offense to be twice put in jeopardy of a penalty unless new evidence of high relevance came to light.
-* **§III.14.** No person shall be deprived of the right to own, manufacture, sell, and bear arms unless declared otherwise by a court of law on mental health grounds.
+* **§III.14.** No person shall be deprived of the right to own, manufacture, sell, transport, and bear arms unless declared otherwise by a court of law on mental health grounds, nor shall licensing be used to infringe upon this right.
 * **§III.15.** No person shall be prevented from challenging an administrative decision given in his or her respect via the procedure of judicial review.
 * **§III.16.** No person shall be tried for disobedience against an unlawful action of any agent of the Public Administration and/or against unconstitutional law.
 * **§III.17.** No person shall be deprived of his or her citizenship otherwise than by a court of law.


### PR DESCRIPTION
The U.S. Constitution protects the right of the people to keep and bear arms. Nevertheless, there are many infringements upon and violations of this right.

Often we see people arrested simply for having a gun in their car, or while moving their household from one place to another. We also see licensing requirements used to restrict gun ownership. Often when people apply for a license, it is not granted, or the terms are too restrictive to make gun ownership practically available.

The changes in this pull request are designed to ensure the government absolutely cannot infringe upon the right of the people to bear arms, based on problems that have historically occurred in the USA.