### PR TITLE
Fair Representation

### DIFF
--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -88,7 +88,7 @@ The Free Republic of Liberland shall be governed by the Public Administration in
   * **§II.1(2)** The Assembly may extend or shorten its session with a simple majority vote of the overall number of Assembly Representatives.
   * **§II.1(3)** The Assembly may reconvene at any time whatsoever upon the call of the Assembly Speaker.
   * **§II.1(4)** The Assembly shall not be dissolved, nor shall its session be interrupted, by any other branch of the Public Administration.
-* **§II.2.** The Assembly shall consist of twenty Assembly Representatives.
+* **§II.2.** The Assembly shall consist of at least twenty Assembly Representatives. The Citizens having a right to fair representation, there shall be at least one Assembly Representative for every ten thousand Citizens.
   * **§II.2(1)** All Assembly Representatives shall receive symbolic remuneration for their service which does not constitute a significant burden on the Annual Budget and does not exceed 5% of the Annual Budget spending in any event.
   * **§II.2(2)** No Person shall hold the office of an Assembly Representative whilst holding any other public office within the executive or judicial branch of the Public Administration concurrently.
   * **§II.2(3)** No Assembly Representative shall be precluded from taking part in any Assembly vote and/or debate by virtue of being detained prior to his or her trial.


### PR DESCRIPTION
This pull request will result in 20 Assembly Representatives until there are over 200,000 Citizens.

After that, there will be 21 Representatives for 210,000 Citizens, 22 Representatives for 220,000 Citizens... 50 Representatives for 500,000 citizens, and so on.

Without this change, the vote of the people will be steadily diluted over time as the number of Citizens grows. **We have seen this problem in the United States, where each Representative "represents" over 700,000 people, and the people thus no longer have fair representation in Congress.**

Once the vote of the people becomes diluted, it may become impossible to fix this later. Better to make sure they never get diluted in the first place.
