### PR TITLE
New provision: Determining when a person can be detained or imprisoned

### DIFF
--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -74,6 +74,7 @@ The Bill of Rights shall constitute the integral part of the Constitution and sh
   * **§II.39(6)** to not be compelled to be a witness against oneself, or Persons whose penalization one would rightfully feel as the penalization of oneself;
   * **§II.39(7)** to the assistance of legal counsel free of charge where appropriate;
   * **§II.39(8)** to the assistance of an interpreter if one does not speak the language in which the hearing is conducted, free of charge where appropriate. 
+* * **§II.40.** No law shall allow for any Person to be detained or imprisoned in any way provided that he poses no future and/or present threat to others and their property, otherwise pursuant to a Warrant.  
 
 
 ## Political Institutions

--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -74,7 +74,7 @@ The Bill of Rights shall constitute the integral part of the Constitution and sh
   * **§II.39(6)** to not be compelled to be a witness against oneself, or Persons whose penalization one would rightfully feel as the penalization of oneself;
   * **§II.39(7)** to the assistance of legal counsel free of charge where appropriate;
   * **§II.39(8)** to the assistance of an interpreter if one does not speak the language in which the hearing is conducted, free of charge where appropriate. 
-* **§II.40.** No law shall allow for any Person to be detained or imprisoned in any way provided that he poses no future and/or present threat to others and their property, otherwise pursuant to a Warrant.  
+* **§II.40.** No law shall allow for any Person to be detained or imprisoned, in any way, provided that he poses no future and/or present threat to others and their property, otherwise pursuant to a Warrant.  
 
 
 ## Political Institutions

--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -74,7 +74,7 @@ The Bill of Rights shall constitute the integral part of the Constitution and sh
   * **§II.39(6)** to not be compelled to be a witness against oneself, or Persons whose penalization one would rightfully feel as the penalization of oneself;
   * **§II.39(7)** to the assistance of legal counsel free of charge where appropriate;
   * **§II.39(8)** to the assistance of an interpreter if one does not speak the language in which the hearing is conducted, free of charge where appropriate. 
-* * **§II.40.** No law shall allow for any Person to be detained or imprisoned in any way provided that he poses no future and/or present threat to others and their property, otherwise pursuant to a Warrant.  
+* **§II.40.** No law shall allow for any Person to be detained or imprisoned in any way provided that he poses no future and/or present threat to others and their property, otherwise pursuant to a Warrant.  
 
 
 ## Political Institutions


### PR DESCRIPTION
I propose a new provision that will make it so that any form of imprisonment or confinement will be allowed only on the condition that a person can be labeled as a threat to others.  

In the case of detainment, it will ensure that police will conduct arrests only when it's absolutely necessary for the protection of others and their property. If they want to bring someone in for questioning, they can do that provided they have a warrant.

In the case of imprisonment, it will ensure that only people who are actually dangerous to society sit in prison. Putting non-violent offenders in prison is both unnecessary and expensive, I see no reason why that should be the case. 

As of now, the Constitution allows for people to be detained for up to 24 hours even if it's for small misdemeanors and civil cases. 

We should remember that arresting a person involves taking away his liberties for a while, and it should therefore be limited to situations where it is absolutely necessary.

 
>§II.40 . No law shall allow for any Person to be detained or imprisoned, in any way, provided that he poses no future and/or present threat to others and their property, otherwise pursuant to a Warrant.  