### PR TITLE
Huge filibuster loophole fix

### DIFF
--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -127,7 +127,7 @@ The Free Republic of Liberland shall be governed by the Public Administration in
   * **§III.8(1)** Any Assembly Representative who is found filibustering on duty shall have his/her speech regarding the proposed bill put to a halt.
   * **§III.8(2)** To deem someone as filibustering, the following requirments must be met:
     * **§III.8(2)(a)** The speech must be at least one hour long. 
-    * **§III.8(2)(b)** Three fourths of the Assembly Representatives must vote 'Aye' to an Assembly Representative filibustering.
+    * **§III.8(2)(b)** Three fourths of the Assembly Representatives must vote 'Aye' to deem an Assembly Representative of filibustering.
       * **§III.8(2)(b)(A)** A vote regarding an Assembly Representative filibustering shall be held immediately if at least five Assembly Representatives indicate they would like to vote, putting a temporary pause on one's speech; the speech may proceed if no change has occurred.
 * **§III.9.** The Assembly shall elect the Chancellor of the Free Republic of Liberland, who shall form the Cabinet of the Free Republic of Liberland with a simple majority vote of all Assembly Representatives.
   * **§III.9(1)** If no Chancellor is elected for more than ninety days, the General Election must be held.

--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -128,7 +128,7 @@ The Free Republic of Liberland shall be governed by the Public Administration in
   * **§III.8(2)** To deem someone as filibustering, the following requirments must be met:
     * **§III.8(2)(a)** The speech must be at least one hour long. 
     * **§III.8(2)(b)** Three fourths of the Assembly Representatives must vote 'Aye' to an Assembly Representative filibustering.
-      * **§III.8(2)(b)(A)** A vote regarding an Assembly Representative filibustering shall be held immediately if at least five Assembly Representatives indicate they would like to vote, putting a temporary pause of one's speech; the speech may proceed if no change has occurred.
+      * **§III.8(2)(b)(A)** A vote regarding an Assembly Representative filibustering shall be held immediately if at least five Assembly Representatives indicate they would like to vote, putting a temporary pause on one's speech; the speech may proceed if no change has occurred.
 * **§III.9.** The Assembly shall elect the Chancellor of the Free Republic of Liberland, who shall form the Cabinet of the Free Republic of Liberland with a simple majority vote of all Assembly Representatives.
   * **§III.9(1)** If no Chancellor is elected for more than ninety days, the General Election must be held.
   * **§III.9(2)** The Assembly shall have the power to withdraw confidence from the Chancellor along with the Cabinet by passing the constructive motion of no confidence with a simple majority vote of all Assembly Representatives only if there is a majority for a prospective successor.

--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -127,7 +127,7 @@ The Free Republic of Liberland shall be governed by the Public Administration in
   * **§III.8(1)** Any Assembly Representative who is found filibustering on duty shall have his/her speech regarding the proposed bill put to a halt.
   * **§III.8(2)** To deem someone as filibustering, the following requirments must be met:
     * **§III.8(2)(a)** The speech must be at least one hour long. 
-    * **§III.8(2)(b)** Three fourths of the Assembly Representatives must vote yes to an Assembly Representative filibustering.
+    * **§III.8(2)(b)** Three fourths of the Assembly Representatives must vote 'Aye' to an Assembly Representative filibustering.
       * **§III.8(2)(b)(A)** A vote regarding an Assembly Representative filibustering shall be held immediately if at least five Assembly Representatives indicate they would like to vote, putting a temporary pause of one's speech; the speech may proceed if no change has occurred.
 * **§III.9.** The Assembly shall elect the Chancellor of the Free Republic of Liberland, who shall form the Cabinet of the Free Republic of Liberland with a simple majority vote of all Assembly Representatives.
   * **§III.9(1)** If no Chancellor is elected for more than ninety days, the General Election must be held.

--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -128,7 +128,7 @@ The Free Republic of Liberland shall be governed by the Public Administration in
   * **§III.8(2)** To deem someone as filibustering, the following requirments must be met:
     * **§III.8(2)(a)** The speech must be at least one hour long. 
     * **§III.8(2)(b)** Three fourths of the Assembly Representatives must vote 'Aye' to deem an Assembly Representative of filibustering.
-      * **§III.8(2)(b)(A)** A vote regarding an Assembly Representative filibustering shall be held immediately if at least five Assembly Representatives indicate they would like to vote, putting a temporary pause on one's speech; the speech may proceed if no change has occurred.
+      * **§III.8(2)(b)(A)** A vote regarding an Assembly Representative filibustering shall be held immediately if at least five Assembly Representatives indicate they would like to vote, putting a temporary pause on the speech being voted on; the speech may proceed if no change has occurred.
 * **§III.9.** The Assembly shall elect the Chancellor of the Free Republic of Liberland, who shall form the Cabinet of the Free Republic of Liberland with a simple majority vote of all Assembly Representatives.
   * **§III.9(1)** If no Chancellor is elected for more than ninety days, the General Election must be held.
   * **§III.9(2)** The Assembly shall have the power to withdraw confidence from the Chancellor along with the Cabinet by passing the constructive motion of no confidence with a simple majority vote of all Assembly Representatives only if there is a majority for a prospective successor.

--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -124,6 +124,11 @@ The Free Republic of Liberland shall be governed by the Public Administration in
   * **§III.7(1)** The Bill proposed by the Cabinet shall be made public prior to the Assembly's debate on them.
   * **§III.7(2)** All drafts of Bills proposed to the Cabinet shall be made public before the Cabinet’s acceptance or rejection.
 * **§III.8.** Every Assembly Representative shall have the right to express one's opinion on the proposed Bill at least once before the vote takes place, without any time limit.
+  * **§III.8(1)** Any Assembly Representative who is found filibustering on duty shall have his/her speech regarding the proposed bill put to a halt.
+  * **§III.8(2)** To deem someone as filibustering, the following requirments must be met:
+    * **§III.8(2)(a)** The speech must be at least one hour long. 
+    * **§III.8(2)(b)** Three fourths of the Assembly Representatives must vote yes to an Assembly Representative filibustering.
+      * **§III.8(2)(b)(A)** A vote regarding an Assembly Representative filibustering shall be held immediately if at least five Assembly Representatives indicate they would like to vote, putting a temporary pause of one's speech; the speech may proceed if no change has occurred.
 * **§III.9.** The Assembly shall elect the Chancellor of the Free Republic of Liberland, who shall form the Cabinet of the Free Republic of Liberland with a simple majority vote of all Assembly Representatives.
   * **§III.9(1)** If no Chancellor is elected for more than ninety days, the General Election must be held.
   * **§III.9(2)** The Assembly shall have the power to withdraw confidence from the Chancellor along with the Cabinet by passing the constructive motion of no confidence with a simple majority vote of all Assembly Representatives only if there is a majority for a prospective successor.


### PR DESCRIPTION
  * **§III.8(1)** Any Assembly Representative who is found filibustering on duty shall have his/her speech regarding the proposed bill put to a halt.
  * **§III.8(2)** To deem someone as filibustering, the following requirments must be met:
    * **§III.8(2)(a)** The speech must be at least one hour long. 
    * **§III.8(2)(b)** Three fourths of the Assembly Representatives must vote 'Aye' to deem an Assembly Representative of filibustering.
      * **§III.8(2)(b)(A)** A vote regarding an Assembly Representative filibustering shall be held immediately if at least five Assembly Representatives indicate they would like to vote, putting a temporary pause on the speech being voted on; the speech may proceed if no change has occurred.

this was added under: **§III.8.** Every Assembly Representative shall have the right to express one's opinion on the proposed Bill at least once before the vote takes place, without any time limit.

The without any time limit makes it very easy to severely postpone a bill. It's good cause it doesn't set an exact time limit, but it makes so that people who take a huge amount of time that aren't adding any information not able to. aka filibustering

This is worded a little weird but I think it makes sense overall if you have any suggestions do tell