### PR TITLE
Jury has right to judge the law based on personal sense of justice.

### DIFF
--- a/Liberland-constitution.md
+++ b/Liberland-constitution.md
@@ -360,7 +360,7 @@ The Free Republic of Liberland shall be governed by the Public Administration in
   * **§IV.15(1)** The Jury shall be composed of twelve impartial Citizens drawn randomly from the Electoral Register.
   * **§IV.15(2)** The Jury shall determine the facts and render the verdict according to the law under the direction of the Judge.
   * **§IV.15(3)** The Jury shall deliberate in camera and shall not be required to disclose reasons behind the verdict or be reprimanded for it.
-  * **§IV.15(4)** The Jury shall retain the unequivocal right to acquit and shall be informed of this right; such acquittal shall be final.
+  * **§IV.15(4)** The Jury shall retain the unequivocal right to acquit based on personal sense of justice, and shall be informed of this right; such acquittal shall be final.
   * **§IV.15(5)** The Jury shall convict with no fewer than eleven votes.
   * **§IV.15(6)** All defendants who have been convicted by the Jury shall be sentenced by the Judge as prescribed by law.
   * **§IV.15(7)** The Jury shall render the verdict free from any form of coercion; the Judge may order sequestration of the Jurors should it be required for the independence of the Jury.


### PR DESCRIPTION
I used _"personal sense of justice"_ because the same phrase is already used elsewhere by Liberland law.

This PR continues the discussion from PRs #55, #72, and most recently, #80.

Judges often instruct jurors to do things that violate the jurors' conscience. Many unjust convictions are obtained this way in the United States. Jurors often later express regret at these injustices and their part in them.

Jurors have the right to judge the law (this was the entire historical purpose of the jury) but often courts mis-advise jurors about this fact, and they also excuse jurors who are aware of their right to nullify bad law. That's why it's so important that the entire jury always be clearly informed of their right to judge an unjust law.

The only concern about this previously was that jurors may abuse this process. But in reality, it's the courts who abuse this process, whereas juries only historically use it for good. There was also a concern about biased jurors (the example raised previously was a muslim juror faced with a jihadi defendant.) **But since the entire jury must vote to acquit, this will not be a problem in practice.**

Signed-off-by: FellowTraveler F3llowTraveler@gmail.com
