### PR TITLE
README: linking discussions & Issues + a small grammar improvement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Repository chronicles the drafting of the Liberland Constitution. Until the Constitution is drafted and adopted in a Referendum, the [Articles of the Provisional Government](articles-of-the-provisional-government-of-liberland.md) of Liberland act as the supreme law of the land.
 
-Please visit the **discussions** to propose changes and new institutes. You can open new **Issues** to inform about a possible problem or a need for a change.
+Please visit the **[discussions](https://github.com/liberland/Constitution/discussions)** to propose changes and new institutes. You can open new **[Issues](https://github.com/liberland/Constitution/issues)** to notify us about a possible problem or a need for a change.
 
 The drafting takes place in a Google Doc. The various milestones are then converted to markdown and uploaded to this Repository, and so will be the final draft. The Constitution shall take force after Liberland Citizens adopt it in a Referendum.
 


### PR DESCRIPTION
I was perplexed by the bold **discussions** text for a while as this feature is rarely used on GitHub.  Hopefully a link makes this more clear for others.